### PR TITLE
[ready to merge] travis support for go builds on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ go:
     - 1.4
     - 1.5
 
+os:
+    - linux
+    - osx
+
 install:
     - go get -d -t -v ./...
     - go build -v ./...


### PR DESCRIPTION
Travis supports builds on OS X, so create the configuration to test those as well. Work in progress, don't know if this will work yet.
