### PR TITLE
Travis updates to pull in xml2rfc, run 'make' command in 'rfc' directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ script:
     - go test -v ./...
     - xml2rfc -V
     - bats -v
+    - cd "$TRAVIS_BUILD_DIR"     && make
     - cd "$TRAVIS_BUILD_DIR"/rfc && make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
     - python
     - python-dev
 before_install:
-    - pip install xml2rpc
+    - pip install xml2rfc
 
 install:
     - go get -d -t -v ./...
@@ -28,4 +28,4 @@ install:
 
 script:
     - go test -v ./...
-    - xml2rpc
+    - xml2rfc -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ os:
     - osx
 env:
  - XML2RFC_VERSION=2.5.0
- - XML2RFC_VERSION=2.5.1.dev0
  - XML2RFC_VERSION=2.4.12
 # let the osx builds fail for a while
 matrix:
@@ -21,11 +20,19 @@ addons:
     packages:
     - python
     - python-dev
+# bring in xml2rfc and bats for testing
 before_install:
     - sudo pip install xml2rfc==$XML2RFC_VERSION
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install python-software-properties ; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo add-apt-repository -y ppa:duggan/bats ; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update ; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install bats ; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install bats; fi
 install:
     - go get -d -t -v ./...
     - go build -v ./...
 script:
     - go test -v ./...
     - xml2rfc -V
+    - bats -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,15 @@ go:
 os:
     - linux
     - osx
-
+env:
+ - XML2RFC_VERSION=2.5.0
+ - XML2RFC_VERSION=2.5.1.dev0
+ - XML2RFC_VERSION=2.4.12
 # let the osx builds fail for a while
 matrix:
   allow_failures:
     os:
       - osx
-
 # get our python environment up and running
 addons:
   apt:
@@ -20,12 +22,10 @@ addons:
     - python
     - python-dev
 before_install:
-    - sudo pip install xml2rfc
-
+    - sudo pip install xml2rfc==$XML2RFC_VERSION
 install:
     - go get -d -t -v ./...
     - go build -v ./...
-
 script:
     - go test -v ./...
-    - xml2rfc -v
+    - xml2rfc -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ install:
 
 script:
     - go test -v ./...
+    - xml2rpc

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ script:
     - go test -v ./...
     - xml2rfc -V
     - bats -v
+    - cd rfc && make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,24 @@ language: go
 go:
     - 1.4
     - 1.5
-
 os:
     - linux
     - osx
+
+# let the osx builds fail for a while
+matrix:
+  allow_failures:
+    os:
+      - osx
+
+# get our python environment up and running
+addons:
+  apt:
+    packages:
+    - python
+    - python-dev
+before_install:
+    - pip install xml2rpc
 
 install:
     - go get -d -t -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-
+sudo: required
 go:
     - 1.4
     - 1.5
@@ -20,7 +20,7 @@ addons:
     - python
     - python-dev
 before_install:
-    - pip install xml2rfc
+    - sudo pip install xml2rfc
 
 install:
     - go get -d -t -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ script:
     - go test -v ./...
     - xml2rfc -V
     - bats -v
-    - cd rfc && make all
+    - cd "$TRAVIS_BUILD_DIR"/rfc && make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ go:
 os:
     - linux
     - osx
+python:
+    - 2.7
+    - 3.4
+    - 3.5
 env:
  - XML2RFC_VERSION=2.5.0
  - XML2RFC_VERSION=2.4.12


### PR DESCRIPTION
This is a first pass at an integration test. 

The provided version of .travis.yml sets up a matrix that tests

Python (whatever the system provides; we should pick a version)
Go 1.4, 1.5
xml2rfc 2.4.12, 2.5.0 (via pip install)
Linux, OS X

or 8 separate tests. It then runs 'make' and 'cd rfc; make'.

Also installed in this is `bats` but I didn't go further to create tests there.

https://travis-ci.org/vielmetti/mmark/builds/80766612 is a sample build (all green). 
