### PR TITLE
Implement relative includes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tags
 mmark/mmark
+mmark/mmark.exe
 ietf/eppext-keyrelay.pdc
 *.swp

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ implements the following extensions:
     to use 2 backslashes it the end of the line.\\
 
 *   **Includes**, support including files with `{{filename}}` syntax. This is only
-    done when include is started at the beginning of a line.
+    done when include is started at the beginning of a line. The filename is
+    specified with forward slashes `/`.
 
 *   **Code Block Includes**, use the syntax `<{{code/hello.c}}[address]`, where
     address is the syntax described in <https://godoc.org/golang.org/x/tools/present/>, the

--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ implements the following extensions:
     to use 2 backslashes it the end of the line.\\
 
 *   **Includes**, support including files with `{{filename}}` syntax. This is only
-    done when include is started at the beginning of a line. The filename is
-    specified with forward slashes `/`.
+    done when include is started at the beginning of a line. The path separator is
+    forward slash `/`. Even on non-Unix environments.
 
 *   **Code Block Includes**, use the syntax `<{{code/hello.c}}[address]`, where
     address is the syntax described in <https://godoc.org/golang.org/x/tools/present/>, the

--- a/block.go
+++ b/block.go
@@ -1155,21 +1155,14 @@ func (p *parser) fencedCode(out *bytes.Buffer, data []byte, doRender bool) int {
 		beg = end
 	}
 	var caption bytes.Buffer
-	line := beg
 	j := beg
-	if bytes.HasPrefix(bytes.TrimSpace(data[j:]), []byte("Figure: ")) {
-		for line < len(data) {
-			j++
-			// find the end of this line
-			for data[j-1] != '\n' {
-				j++
-			}
-			if p.isEmpty(data[line:j]) > 0 {
-				break
-			}
-			line = j
+
+	span := linespan{beg, beg}
+	if span.next(data) {
+		if bytes.HasPrefix(bytes.TrimSpace(data[span.begin:span.end]), []byte("Figure: ")) {
+			p.inline(&caption, data[span.begin:span.end-1])
+			j = span.end
 		}
-		p.inline(&caption, data[beg+8:j-1])
 	}
 
 	syntax := ""

--- a/block.go
+++ b/block.go
@@ -1155,14 +1155,21 @@ func (p *parser) fencedCode(out *bytes.Buffer, data []byte, doRender bool) int {
 		beg = end
 	}
 	var caption bytes.Buffer
+	line := beg
 	j := beg
-
-	line := linespan{beg, beg}
-	if line.next(data) {
-		if bytes.HasPrefix(bytes.TrimSpace(data[line.begin:line.end]), []byte("Figure: ")) {
-			p.inline(&caption, data[line.begin:line.end-1])
-			j = line.end
+	if bytes.HasPrefix(bytes.TrimSpace(data[j:]), []byte("Figure: ")) {
+		for line < len(data) {
+			j++
+			// find the end of this line
+			for data[j-1] != '\n' {
+				j++
+			}
+			if p.isEmpty(data[line:j]) > 0 {
+				break
+			}
+			line = j
 		}
+		p.inline(&caption, data[beg+8:j-1])
 	}
 
 	syntax := ""

--- a/block.go
+++ b/block.go
@@ -1157,11 +1157,11 @@ func (p *parser) fencedCode(out *bytes.Buffer, data []byte, doRender bool) int {
 	var caption bytes.Buffer
 	j := beg
 
-	span := linespan{beg, beg}
-	if span.next(data) {
-		if bytes.HasPrefix(bytes.TrimSpace(data[span.begin:span.end]), []byte("Figure: ")) {
-			p.inline(&caption, data[span.begin:span.end-1])
-			j = span.end
+	line := linespan{beg, beg}
+	if line.next(data) {
+		if bytes.HasPrefix(bytes.TrimSpace(data[line.begin:line.end]), []byte("Figure: ")) {
+			p.inline(&caption, data[line.begin:line.end-1])
+			j = line.end
 		}
 	}
 

--- a/code.go
+++ b/code.go
@@ -42,7 +42,7 @@ var SourceCodeTypes = map[string]bool{
 func (p *parser) parseCode(addr []byte, file []byte) []byte {
 	bytes.TrimSpace(addr)
 
-	fullname := absname(p.cwd, string(file))
+	fullname := absname(p.workingDirectory, string(file))
 	textBytes, err := p.fs.ReadFile(fullname)
 	if err != nil {
 		printf(nil, "failed: `%s': %s", string(file), err)

--- a/code.go
+++ b/code.go
@@ -42,7 +42,7 @@ var SourceCodeTypes = map[string]bool{
 func (p *parser) parseCode(addr []byte, file []byte) []byte {
 	bytes.TrimSpace(addr)
 
-	fullname := absname(p.workingDirectory, string(file))
+	fullname := absname(p.workingDirectory, file)
 	textBytes, err := p.fs.ReadFile(fullname)
 	if err != nil {
 		printf(nil, "failed: `%s': %s", string(file), err)

--- a/code.go
+++ b/code.go
@@ -10,7 +10,6 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"regexp"
 	"strconv"
 	"unicode/utf8"
@@ -40,10 +39,10 @@ var SourceCodeTypes = map[string]bool{
 }
 
 // parseCode parses a code address directive.
-func parseCode(addr []byte, file []byte) []byte {
+func (p *parser) parseCode(addr []byte, file []byte) []byte {
 	bytes.TrimSpace(addr)
 
-	textBytes, err := ioutil.ReadFile(string(file))
+	textBytes, err := p.fs.readFile(string(file))
 	if err != nil {
 		printf(nil, "failed: `%s': %s", string(file), err)
 		return nil

--- a/code.go
+++ b/code.go
@@ -42,7 +42,8 @@ var SourceCodeTypes = map[string]bool{
 func (p *parser) parseCode(addr []byte, file []byte) []byte {
 	bytes.TrimSpace(addr)
 
-	textBytes, err := p.fs.readFile(string(file))
+	fullname := absname(p.cwd, string(file))
+	textBytes, err := p.fs.ReadFile(fullname)
 	if err != nil {
 		printf(nil, "failed: `%s': %s", string(file), err)
 		return nil

--- a/filesystem.go
+++ b/filesystem.go
@@ -7,27 +7,27 @@ import (
 	"path/filepath"
 )
 
-// FileSystem implements access to files. The elements in a file path are
+// fileSystem implements access to files. The elements in a file path are
 // separated by slash ('/', U+002F) characters, regardless of host
 // operating system convention.
-type FileSystem interface {
+type fileSystem interface {
 	// ReadFile reads the file named by filename and returns the contents.
 	ReadFile(name string) ([]byte, error)
 }
 
-// dir implements FileSystem using the native file system restricted to a
+// dir implements fileSystem using the native file system restricted to a
 // specific directory tree.
 //
-// While the FileSystem.ReadFile method takes '/'-separated paths,
-// a Dir's string value is a filename on the native file system,
+// While the fileSystem.ReadFile method takes '/'-separated paths,
+// a dir's string value is a filename on the native file system,
 // not a URL, so it is separated by filepath.Separator,
 // which isn't necessarily '/'.
 //
-// An empty Dir is treated as "."
-type Dir string
+// An empty dir is treated as "."
+type dir string
 
 // ReadFile reads the file named by filename and returns the contents.
-func (d Dir) ReadFile(name string) ([]byte, error) {
+func (d dir) ReadFile(name string) ([]byte, error) {
 	dir := string(d)
 	if dir == "" {
 		dir = "."
@@ -36,7 +36,7 @@ func (d Dir) ReadFile(name string) ([]byte, error) {
 	return ioutil.ReadFile(fullname)
 }
 
-// virtualFS implements FileSystem using an in-memory map to define the FileSystem
+// virtualFS implements fileSystem using an in-memory map to define the fileSystem
 // this is used for testing
 type virtualFS map[string]string
 

--- a/filesystem.go
+++ b/filesystem.go
@@ -1,0 +1,50 @@
+package mmark
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+// fileSystem implements access to files. The elements in a file path are
+// separated by slash ('/', U+002F) characters, regardless of host
+// operating system convention.
+type fileSystem interface {
+	// readFile reads the file named by filename and returns the contents.
+	readFile(name string) ([]byte, error)
+}
+
+// dir implements fileSystem using the native file system restricted to a
+// specific directory tree.
+//
+// While the fileSystem.readFile method takes '/'-separated paths,
+// a Dir's string value is a filename on the native file system,
+// not a URL, so it is separated by filepath.Separator,
+// which isn't necessarily '/'.
+//
+// An empty Dir is treated as "."
+type dir string
+
+// readFile reads the file named by filename and returns the contents.
+func (d dir) readFile(name string) ([]byte, error) {
+	dir := string(d)
+	if dir == "" {
+		dir = "."
+	}
+	fullname := filepath.Join(dir, filepath.FromSlash(path.Clean("/"+name)))
+	return ioutil.ReadFile(fullname)
+}
+
+// virtualFS implements fileSystem using an in-memory map to define the filesystem
+type virtualFS map[string]string
+
+// readFile returns the content for appropriate filename
+// if the name does not exist, then it will return os.ErrNotExist
+func (fs virtualFS) readFile(name string) ([]byte, error) {
+	content, ok := fs[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return []byte(content), nil
+}

--- a/filesystem.go
+++ b/filesystem.go
@@ -12,7 +12,7 @@ import (
 // operating system convention.
 type fileSystem interface {
 	// ReadFile reads the file named by filename and returns the contents.
-	ReadFile(name string) ([]byte, error)
+	ReadFile(name []byte) ([]byte, error)
 }
 
 // dir implements fileSystem using the native file system restricted to a
@@ -27,12 +27,12 @@ type fileSystem interface {
 type dir string
 
 // ReadFile reads the file named by filename and returns the contents.
-func (d dir) ReadFile(name string) ([]byte, error) {
+func (d dir) ReadFile(name []byte) ([]byte, error) {
 	dir := string(d)
 	if dir == "" {
 		dir = "."
 	}
-	fullname := filepath.Join(dir, filepath.FromSlash(path.Clean("/"+name)))
+	fullname := filepath.Join(dir, filepath.FromSlash(path.Clean("/"+string(name))))
 	return ioutil.ReadFile(fullname)
 }
 
@@ -42,8 +42,8 @@ type virtualFS map[string]string
 
 // ReadFile returns the content for appropriate filename
 // if the name does not exist, then it will return os.ErrNotExist
-func (fs virtualFS) ReadFile(name string) ([]byte, error) {
-	search := path.Clean("/" + name)
+func (fs virtualFS) ReadFile(name []byte) ([]byte, error) {
+	search := path.Clean("/" + string(name))
 	content, ok := fs[search]
 	if !ok {
 		return nil, os.ErrNotExist
@@ -51,9 +51,9 @@ func (fs virtualFS) ReadFile(name string) ([]byte, error) {
 	return []byte(content), nil
 }
 
-func absname(cwd string, name string) string {
+func absname(cwd string, name []byte) []byte {
 	if len(name) > 0 && name[0] == '/' {
 		return name
 	}
-	return path.Join(cwd, name)
+	return []byte(path.Join(cwd, string(name)))
 }

--- a/inline.go
+++ b/inline.go
@@ -181,13 +181,34 @@ func codeSpan(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 		return end
 	}
 
-	// a code span
+	// is it a code span
 	if !isBlock {
 		p.r.CodeSpan(out, data[fBegin:fEnd])
 		return end
 	}
 
-	p.r.BlockCode(out, data[fBegin:fEnd], lang, nil, false, true)
+	code := data[fBegin:fEnd]
+
+	var caption bytes.Buffer
+
+	co := ""
+	if p.ial != nil {
+		co = p.ial.Value("callout")
+	}
+
+	p.r.SetInlineAttr(p.ial)
+	p.ial = nil
+
+	if co != "" {
+		var callout bytes.Buffer
+		callouts(p, &callout, code, 0, co)
+		p.r.BlockCode(out, callout.Bytes(), lang, caption.Bytes(), p.insideFigure, true)
+	} else {
+		p.callouts = nil
+		p.r.BlockCode(out, code, lang, caption.Bytes(), p.insideFigure, false)
+	}
+	p.r.SetInlineAttr(nil) // reset it again. TODO(miek): double check
+
 	return end
 }
 

--- a/inline.go
+++ b/inline.go
@@ -189,8 +189,6 @@ func codeSpan(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 
 	code := data[fBegin:fEnd]
 
-	var caption bytes.Buffer
-
 	co := ""
 	if p.ial != nil {
 		co = p.ial.Value("callout")
@@ -202,10 +200,10 @@ func codeSpan(p *parser, out *bytes.Buffer, data []byte, offset int) int {
 	if co != "" {
 		var callout bytes.Buffer
 		callouts(p, &callout, code, 0, co)
-		p.r.BlockCode(out, callout.Bytes(), lang, caption.Bytes(), p.insideFigure, true)
+		p.r.BlockCode(out, callout.Bytes(), lang, nil, false, true)
 	} else {
 		p.callouts = nil
-		p.r.BlockCode(out, code, lang, caption.Bytes(), p.insideFigure, false)
+		p.r.BlockCode(out, code, lang, nil, false, false)
 	}
 	p.r.SetInlineAttr(nil) // reset it again. TODO(miek): double check
 

--- a/inline.go
+++ b/inline.go
@@ -738,12 +738,6 @@ func (p *parser) inlineHtmlComment(out *bytes.Buffer, data []byte) int {
 
 // '<' when tags or autolinks are allowed
 func leftAngle(p *parser, out *bytes.Buffer, data []byte, offset int) int {
-	if p.flags&EXTENSION_INCLUDE != 0 {
-		if j := p.codeInclude(out, data[offset:]); j > 0 {
-			return j
-		}
-	}
-
 	data = data[offset:]
 	altype := _LINK_TYPE_NOT_AUTOLINK
 	end := tagLength(data, &altype)

--- a/inline_test.go
+++ b/inline_test.go
@@ -169,7 +169,6 @@ func TestEmphasis(t *testing.T) {
 
 		"*What is A\\* algorithm?*\n",
 		"<p><em>What is A* algorithm?</em></p>\n",
-
 	}
 	doTestsInline(t, tests)
 }
@@ -860,7 +859,9 @@ No longer in the footnote
 
 <p>Paragraph 2</p>
 
-<p><code>some code</code></p>
+<p>
+<pre><code>some code</code></pre>
+</p>
 
 <p>Paragraph 3</p>
 </li>

--- a/iterator.go
+++ b/iterator.go
@@ -1,0 +1,23 @@
+package mmark
+
+import "bytes"
+
+// linespan implements a minimal line iterator over '\n' delimited content
+type linespan struct{ begin, end int }
+
+// next updates begin and end to point to the next line
+func (sc *linespan) next(content []byte) bool {
+	sc.begin = sc.end
+	if sc.begin >= len(content) {
+		return false
+	}
+
+	off := bytes.IndexByte(content[sc.begin:], '\n')
+	if off >= 0 {
+		sc.end = sc.begin + off + 1
+		return true
+	}
+
+	sc.end = len(content)
+	return true
+}

--- a/markdown.go
+++ b/markdown.go
@@ -927,11 +927,11 @@ func (p *parser) include(out *bytes.Buffer, data []byte, depth int) int {
 		return 0
 	}
 
-	name := string(data[i+2 : end-2])
+	name := data[i+2 : end-2]
 	fullname := absname(p.workingDirectory, name)
 	input, err := p.fs.ReadFile(fullname)
 	if err != nil {
-		printf(p, "failed: `%s': %s", name, err)
+		printf(p, "failed: `%s': %s", string(name), err)
 		return end
 	}
 
@@ -946,7 +946,7 @@ func (p *parser) include(out *bytes.Buffer, data []byte, depth int) int {
 	defer func() {
 		p.workingDirectory = prevWorkingDirectory
 	}()
-	p.workingDirectory = path.Dir(fullname)
+	p.workingDirectory = path.Dir(string(fullname))
 
 	first := firstPass(p, input, depth+1)
 	out.Write(first.Bytes())

--- a/markdown.go
+++ b/markdown.go
@@ -1010,7 +1010,7 @@ func (p *parser) codeInclude(out *bytes.Buffer, data []byte, indent []byte) int 
 	}
 	// end the codeblock
 	out.Write(indent)
-	out.WriteString("```\n")
+	out.WriteString("```")
 
 	return end
 }

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -94,3 +94,29 @@ func TestCodeblockInList(t *testing.T) {
 		t.Errorf("got\n%s\nexpected\n%s\n", result, expect)
 	}
 }
+
+func TestLearningGoRegression(t *testing.T) {
+	fs := virtualFS{
+		"main.md": `
+{callout="//"}
+<{{test.go}}
+Figure: Go routines in action.
+`,
+		"test.go": "123456789",
+	}
+	expect := `<ol><li>Alpha<ol><li>Beta<pre><code class="language-go">123456789</code></pre></li></ol></li><li>Gamma <code>123456789</code><ul><li>Delta</li><li>Iota<pre><code class="language-go">123456789</code></pre></li></ul></li><li>Kappa</li></ol>`
+
+	r := HtmlRenderer(0, "", "")
+	p := newParser(fs, r, EXTENSION_INCLUDE|EXTENSION_FENCED_CODE)
+	input, err := p.fs.readFile("main.md")
+	if err != nil {
+		t.Error(err)
+	}
+
+	first := firstPass(p, input, 0)
+	second := secondPass(p, first.Bytes(), 0)
+	result := strings.Replace(second.String(), "\n", "", -1)
+	if result != expect {
+		t.Errorf("got\n%s\nexpected\n%s\n", result, expect)
+	}
+}

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -95,16 +95,14 @@ func TestCodeblockInList(t *testing.T) {
 	}
 }
 
-func TestLearningGoRegression(t *testing.T) {
+func TestExtraLineAfterBlockCrash(t *testing.T) {
 	fs := virtualFS{
 		"main.md": `
-{callout="//"}
 <{{test.go}}
+
 Figure: Go routines in action.
 `,
-		"test.go": "123456789",
-	}
-	expect := `<ol><li>Alpha<ol><li>Beta<pre><code class="language-go">123456789</code></pre></li></ol></li><li>Gamma <code>123456789</code><ul><li>Delta</li><li>Iota<pre><code class="language-go">123456789</code></pre></li></ul></li><li>Kappa</li></ol>`
+		"test.go": "123456"}
 
 	r := HtmlRenderer(0, "", "")
 	p := newParser(fs, r, EXTENSION_INCLUDE|EXTENSION_FENCED_CODE)
@@ -114,9 +112,5 @@ Figure: Go routines in action.
 	}
 
 	first := firstPass(p, input, 0)
-	second := secondPass(p, first.Bytes(), 0)
-	result := strings.Replace(second.String(), "\n", "", -1)
-	if result != expect {
-		t.Errorf("got\n%s\nexpected\n%s\n", result, expect)
-	}
+	secondPass(p, first.Bytes(), 0)
 }

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -1,0 +1,30 @@
+package mmark
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNestedInclude(t *testing.T) {
+	fs := virtualFS{
+		"A.md":    "{{B.md}}",
+		"B.md":    "{{C.md}}",
+		"C.md":    "XYZYX\n\n<{{test.go}}[/START OMIT/,/END OMIT/]\n",
+		"test.go": "abcdef\n// START OMIT\n12345678\n// END OMIT\n",
+	}
+	expect := "<p>XYZYX</p><p><pre><code class=\"language-go\">12345678</code></pre></p>"
+
+	r := HtmlRenderer(0, "", "")
+	p := newParser(fs, r, EXTENSION_INCLUDE)
+	input, err := p.fs.readFile("A.md")
+	if err != nil {
+		t.Error(err)
+	}
+
+	first := firstPass(p, input, 0)
+	second := secondPass(p, first.Bytes(), 0)
+	result := strings.Replace(second.String(), "\n", "", -1)
+	if result != expect {
+		t.Errorf("got `%s`\nexpected `%s`", result, expect)
+	}
+}

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -43,7 +43,7 @@ func TestIncludeCodeblockInList(t *testing.T) {
 		"test.go": "123\n\t456\n789",
 	}
 
-	expect := `<ol><li><p>Alpha</p><ol><li>Beta <code>go123	456789</code></li></ol></li><li><p>Gamma <code>go123	456789</code></p><ul><li>Delta<ul><li>Iota<code>go123	456789</code></li></ul></li></ul></li><li><p>Kappa</p></li></ol>`
+	expect := `<ol><li><p>Alpha</p><ol><li>Beta <pre><code class="language-go">123	456789</code></pre></li></ol></li><li><p>Gamma <pre><code class="language-go">123	456789</code></pre></p><ul><li>Delta<ul><li>Iota<pre><code class="language-go">123	456789</code></pre></li></ul></li></ul></li><li><p>Kappa</p></li></ol>`
 	r := HtmlRenderer(0, "", "")
 	p := newParser(fs, r, EXTENSION_INCLUDE)
 	input, err := p.fs.readFile("main.md")
@@ -64,12 +64,11 @@ func TestCodeblockInList(t *testing.T) {
 	fs := virtualFS{
 		"main.md": `
 1. Alpha
-  1. Beta ` + qqq + ` go
-123456789
-` + qqq + `
-2. Gamma ` + qqq + ` go
-123456789
-` + qqq + `
+  1. Beta
+  ` + qqq + ` go
+  123456789
+  ` + qqq + `
+2. Gamma ` + qqq + `123456789` + qqq + `
   * Delta
     * Iota
       ` + qqq + ` go
@@ -79,7 +78,7 @@ func TestCodeblockInList(t *testing.T) {
 `,
 		"test.go": "123456789",
 	}
-	expect := `<ol><li>Alpha<ol><li>Beta <code>go123456789</code></li></ol></li><li>Gamma <code>go123456789</code><ul><li>Delta</li><li>Iota<code>go123456789</code></li></ul></li><li>Kappa</li></ol>`
+	expect := `<ol><li>Alpha<ol><li>Beta<pre><code class="language-go">123456789</code></pre></li></ol></li><li>Gamma <code>123456789</code><ul><li>Delta</li><li>Iota<pre><code class="language-go">123456789</code></pre></li></ul></li><li>Kappa</li></ol>`
 
 	r := HtmlRenderer(0, "", "")
 	p := newParser(fs, r, EXTENSION_INCLUDE)

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -12,7 +12,7 @@ func TestNestedInclude(t *testing.T) {
 		"C.md":    "XYZYX\n\n<{{test.go}}[/START OMIT/,/END OMIT/]\n",
 		"test.go": "abcdef\n// START OMIT\n12345678\n// END OMIT\n",
 	}
-	expect := "<p>XYZYX</p><p><pre><code class=\"language-go\">12345678</code></pre></p>"
+	expect := `<p>XYZYX</p><p><pre><code class="language-go">12345678</code></pre></p>`
 
 	r := HtmlRenderer(0, "", "")
 	p := newParser(fs, r, EXTENSION_INCLUDE)
@@ -26,5 +26,72 @@ func TestNestedInclude(t *testing.T) {
 	result := strings.Replace(second.String(), "\n", "", -1)
 	if result != expect {
 		t.Errorf("got `%s`\nexpected `%s`", result, expect)
+	}
+}
+
+func TestIncludeCodeblockInList(t *testing.T) {
+	fs := virtualFS{
+		"main.md": `
+1. Alpha
+	1. Beta <{{test.go}}
+2. Gamma <{{test.go}}
+	* Delta
+		* Iota
+		<{{test.go}}
+3. Kappa
+`,
+		"test.go": "123\n\t456\n789",
+	}
+
+	expect := `<ol><li><p>Alpha</p><ol><li>Beta <code>go123	456789</code></li></ol></li><li><p>Gamma <code>go123	456789</code></p><ul><li>Delta<ul><li>Iota<code>go123	456789</code></li></ul></li></ul></li><li><p>Kappa</p></li></ol>`
+	r := HtmlRenderer(0, "", "")
+	p := newParser(fs, r, EXTENSION_INCLUDE)
+	input, err := p.fs.readFile("main.md")
+	if err != nil {
+		t.Error(err)
+	}
+
+	first := firstPass(p, input, 0)
+	second := secondPass(p, first.Bytes(), 0)
+	result := strings.Replace(second.String(), "\n", "", -1)
+	if result != expect {
+		t.Errorf("got\n%s\nexpected\n%s\n", result, expect)
+	}
+}
+
+func TestCodeblockInList(t *testing.T) {
+	qqq := "```"
+	fs := virtualFS{
+		"main.md": `
+1. Alpha
+  1. Beta ` + qqq + ` go
+123456789
+` + qqq + `
+2. Gamma ` + qqq + ` go
+123456789
+` + qqq + `
+  * Delta
+    * Iota
+      ` + qqq + ` go
+      123456789
+      ` + qqq + `
+3. Kappa
+`,
+		"test.go": "123456789",
+	}
+	expect := `<ol><li>Alpha<ol><li>Beta <code>go123456789</code></li></ol></li><li>Gamma <code>go123456789</code><ul><li>Delta</li><li>Iota<code>go123456789</code></li></ul></li><li>Kappa</li></ol>`
+
+	r := HtmlRenderer(0, "", "")
+	p := newParser(fs, r, EXTENSION_INCLUDE)
+	input, err := p.fs.readFile("main.md")
+	if err != nil {
+		t.Error(err)
+	}
+
+	first := firstPass(p, input, 0)
+	second := secondPass(p, first.Bytes(), 0)
+	result := strings.Replace(second.String(), "\n", "", -1)
+	if result != expect {
+		t.Errorf("got\n%s\nexpected\n%s\n", result, expect)
 	}
 }

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -16,7 +16,7 @@ func TestNestedInclude(t *testing.T) {
 
 	r := HtmlRenderer(0, "", "")
 	p := newParser(fs, r, EXTENSION_INCLUDE)
-	input, err := p.fs.ReadFile("/A.md")
+	input, err := p.fs.ReadFile([]byte("/A.md"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -46,7 +46,7 @@ func TestIncludeCodeblockInList(t *testing.T) {
 	expect := `<ol><li>Alpha<ol><li>Beta <pre><code class="language-go">123	456789</code></pre></li></ol></li><li>Gamma <pre><code class="language-go">123	456789</code></pre><ul><li>Delta<ul><li>Iota<pre><code class="language-go">123	456789</code></pre></li></ul></li></ul></li><li>Kappa</li></ol>`
 	r := HtmlRenderer(0, "", "")
 	p := newParser(fs, r, EXTENSION_INCLUDE)
-	input, err := p.fs.ReadFile("/main.md")
+	input, err := p.fs.ReadFile([]byte("/main.md"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -82,7 +82,7 @@ func TestCodeblockInList(t *testing.T) {
 
 	r := HtmlRenderer(0, "", "")
 	p := newParser(fs, r, EXTENSION_INCLUDE)
-	input, err := p.fs.ReadFile("/main.md")
+	input, err := p.fs.ReadFile([]byte("/main.md"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -109,7 +109,7 @@ func TestRelativeInclude(t *testing.T) {
 
 	r := HtmlRenderer(0, "", "")
 	p := newParser(fs, r, EXTENSION_INCLUDE)
-	input, err := p.fs.ReadFile("/A.md")
+	input, err := p.fs.ReadFile([]byte("/A.md"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -95,28 +95,6 @@ func TestCodeblockInList(t *testing.T) {
 	}
 }
 
-func TestExtraLineAfterBlockCrash(t *testing.T) {
-	fs := virtualFS{
-		"/main.md": `
-<{{test.go}}
-
-Figure: Go routines in action.
-
-Alpha, beta gamma...
-`,
-		"/test.go": "123456"}
-
-	r := HtmlRenderer(0, "", "")
-	p := newParser(fs, r, EXTENSION_INCLUDE|EXTENSION_FENCED_CODE)
-	input, err := p.fs.ReadFile("/main.md")
-	if err != nil {
-		t.Error(err)
-	}
-
-	first := firstPass(p, input, 0)
-	secondPass(p, first.Bytes(), 0)
-}
-
 func TestRelativeInclude(t *testing.T) {
 	fs := virtualFS{
 		"/A.md":   "{{X/B.md}}",

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -43,7 +43,7 @@ func TestIncludeCodeblockInList(t *testing.T) {
 		"test.go": "123\n\t456\n789",
 	}
 
-	expect := `<ol><li><p>Alpha</p><ol><li>Beta <pre><code class="language-go">123	456789</code></pre></li></ol></li><li><p>Gamma <pre><code class="language-go">123	456789</code></pre></p><ul><li>Delta<ul><li>Iota<pre><code class="language-go">123	456789</code></pre></li></ul></li></ul></li><li><p>Kappa</p></li></ol>`
+	expect := `<ol><li>Alpha<ol><li>Beta <pre><code class="language-go">123	456789</code></pre></li></ol></li><li>Gamma <pre><code class="language-go">123	456789</code></pre><ul><li>Delta<ul><li>Iota<pre><code class="language-go">123	456789</code></pre></li></ul></li></ul></li><li>Kappa</li></ol>`
 	r := HtmlRenderer(0, "", "")
 	p := newParser(fs, r, EXTENSION_INCLUDE)
 	input, err := p.fs.readFile("main.md")
@@ -101,6 +101,8 @@ func TestExtraLineAfterBlockCrash(t *testing.T) {
 <{{test.go}}
 
 Figure: Go routines in action.
+
+Alpha, beta gamma...
 `,
 		"test.go": "123456"}
 

--- a/mmark/main.go
+++ b/mmark/main.go
@@ -143,8 +143,7 @@ func main() {
 	}
 
 	// parse and render
-	fs := mmark.Dir(workingdir)
-	output := mmark.ParseAt(fs, input, renderer, extensions).Bytes()
+	output := mmark.ParseAt(workingdir, input, renderer, extensions).Bytes()
 
 	// output the result
 	out := os.Stdout

--- a/mmark/main.go
+++ b/mmark/main.go
@@ -17,6 +17,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/miekg/mmark"
 )
@@ -57,7 +58,7 @@ func main() {
 	}
 	flag.Parse()
 
-	if version{
+	if version {
 		fmt.Printf("%s+%s\n", mmark.Version, githash)
 		return
 	}
@@ -70,6 +71,8 @@ func main() {
 		page = true
 	}
 
+	workingdir := "."
+
 	// read the input
 	var input []byte
 	var err error
@@ -80,6 +83,7 @@ func main() {
 			log.Fatalf("error reading from standard input: %v", err)
 		}
 	case 1, 2:
+		workingdir = filepath.Dir(args[0])
 		if input, err = ioutil.ReadFile(args[0]); err != nil {
 			log.Fatalf("error reading from %s: %s", args[0], err)
 		}
@@ -139,7 +143,8 @@ func main() {
 	}
 
 	// parse and render
-	output := mmark.Parse(input, renderer, extensions).Bytes()
+	fs := mmark.Dir(workingdir)
+	output := mmark.ParseAt(fs, input, renderer, extensions).Bytes()
 
 	// output the result
 	out := os.Stdout


### PR DESCRIPTION
Now this works as with relative imports.

```
toc.md
chapter1/toc.md
chapter1/A.md
```

Where `toc.md` contains:

```
# Chapter 1
{{chapter1/toc.md}}
```

and  `chapter1/toc.md`:

```
## A
{{A.md}}
```

When specifying `{{/xyz.md}}` will refer to the folder where main file is located. `{{/../xyz.md}}` will resolve to `{{/xyz.md}}`, because it is disallowed to go outside of the root folder.

Fixes #36 
