### PR TITLE
Stop a list when encountering example list

### DIFF
--- a/block.go
+++ b/block.go
@@ -2179,6 +2179,12 @@ gatherlines:
 			p.oliPrefix(chunk) > 0 || p.eliPrefix(chunk) > 0 ||
 			p.dliPrefix(chunk) > 0:
 
+			if *flags&_LIST_TYPE_ORDERED_GROUP == 0 && p.eliPrefix(chunk) > 0 {
+				// This ends this list.
+				*flags |= _LIST_ITEM_END_OF_LIST
+				break gatherlines
+			}
+
 			if containsBlankLine {
 				*flags |= _LIST_ITEM_CONTAINS_BLOCK
 			}

--- a/issue_test.go
+++ b/issue_test.go
@@ -26,3 +26,17 @@ func TestIssue59(t *testing.T) {
 	}
 	doTestsBlockXML(t, tests, EXTENSION_MATTER)
 }
+
+func TestIssue73(t *testing.T) {
+	tests := []string{
+		`* [foo](http://bar)
+
+(@good)  Example
+
+As (@good) says
+`,
+		"<ul>\n<li><eref target=\"http://bar\">foo</eref></li>\n</ul>\n<ol group=\"good\">\n<li>Example</li>\n</ol>\n<t>\nAs (1) says\n</t>\n",
+	}
+
+	doTestsBlockXML(t, tests, commonXmlExtensions)
+}


### PR DESCRIPTION
Break list gathering when we jump from a non-group-example list
to an example list.
