### PR TITLE
Fix breaking out def. list

### DIFF
--- a/block.go
+++ b/block.go
@@ -2196,6 +2196,18 @@ gatherlines:
 					*flags |= _LIST_ITEM_END_OF_LIST
 					break gatherlines
 				}
+
+				if indent <= itemIndent &&
+					((*flags&_LIST_TYPE_DEFINITION != 0 && p.uliPrefix(chunk) > 0) ||
+						(*flags&_LIST_TYPE_DEFINITION != 0 && p.oliPrefix(chunk) > 0) ||
+						(*flags&_LIST_TYPE_DEFINITION != 0 && p.aliPrefix(chunk) > 0) ||
+						(*flags&_LIST_TYPE_DEFINITION != 0 && p.aliPrefixU(chunk) > 0) ||
+						(*flags&_LIST_TYPE_DEFINITION != 0 && p.rliPrefix(chunk) > 0) ||
+						(*flags&_LIST_TYPE_DEFINITION != 0 && p.rliPrefixU(chunk) > 0)) {
+					*flags |= _LIST_ITEM_END_OF_LIST
+					break gatherlines
+				}
+
 				*flags |= _LIST_ITEM_CONTAINS_BLOCK
 			}
 

--- a/issue_test.go
+++ b/issue_test.go
@@ -36,7 +36,24 @@ func TestIssue73(t *testing.T) {
 As (@good) says
 `,
 		"<ul>\n<li><eref target=\"http://bar\">foo</eref></li>\n</ul>\n<ol group=\"good\">\n<li>Example</li>\n</ol>\n<t>\nAs (1) says\n</t>\n",
-	}
 
+		`Mmark
+: A Markdown-superset converter
+
+* [foo](http://bar)`,
+		"<dl>\n<dt>Mmark</dt>\n<dd>A Markdown-superset converter</dd>\n</dl>\n<ul>\n<li><eref target=\"http://bar\">foo</eref></li>\n</ul>\n",
+
+		`Mmark
+: A Markdown-superset converter
+
+ * [foo](http://bar)`,
+		"<dl>\n<dt>Mmark</dt>\n<dd><t>\nA Markdown-superset converter\n</t>\n<ul>\n<li><eref target=\"http://bar\">foo</eref></li>\n</ul></dd>\n</dl>\n",
+
+		`Mmark
+: A Markdown-superset converter
+
+1. [foo](http://bar)`,
+		"<dl>\n<dt>Mmark</dt>\n<dd>A Markdown-superset converter</dd>\n</dl>\n<ol>\n<li><eref target=\"http://bar\">foo</eref></li>\n</ol>\n",
+	}
 	doTestsBlockXML(t, tests, commonXmlExtensions)
 }


### PR DESCRIPTION
Apply the same fix as in #74, but now for definition lists as well.
