### PR TITLE
Update bibliography links to secure ones

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -1107,40 +1107,40 @@ func TestInlineComments(t *testing.T) {
 func TestCitationXML(t *testing.T) {
 	var tests = []string{
 		"[@RFC2525]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC2525\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2525.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC2525\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2525.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"[@!RFC1024]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC1024\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Normative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.1024.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC1024\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Normative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.1024.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"[@?RFC3024]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC3024\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3024.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC3024\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3024.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"[-@RFC3024]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3024.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3024.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"[@?I-D.6man-udpzero]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"I-D.6man-udpzero\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.6man-udpzero.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"I-D.6man-udpzero\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.6man-udpzero.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"[@?I-D.6man-udpzero#06]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"I-D.6man-udpzero\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.draft-6man-udpzero-06.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"I-D.6man-udpzero\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.draft-6man-udpzero-06.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"[@?I-D.6man-udpzero p. 23]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"I-D.6man-udpzero\" section=\"p. 23\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml3/reference.I-D.6man-udpzero.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"I-D.6man-udpzero\" section=\"p. 23\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.6man-udpzero.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"[@RFC2525], as you can see from @RFC2525, as @miekg says",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC2525\"/>, as you can see from <xref target=\"RFC2525\"/>, as @miekg says\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2525.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC2525\"/>, as you can see from <xref target=\"RFC2525\"/>, as @miekg says\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2525.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"[@?RFC2525], as you can see from [@!RFC2525]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC2525\"/>, as you can see from <xref target=\"RFC2525\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Normative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2525.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC2525\"/>, as you can see from <xref target=\"RFC2525\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Normative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2525.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"[@!RFC2525], as you can see from [@?RFC2525]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC2525\"/>, as you can see from <xref target=\"RFC2525\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Normative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2525.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\n<xref target=\"RFC2525\"/>, as you can see from <xref target=\"RFC2525\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Normative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.2525.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"More of that in [@?ISO.8571-2.1988]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\nMore of that in <xref target=\"ISO.8571-2.1988\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml2/reference.ISO.8571-2.1988.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\nMore of that in <xref target=\"ISO.8571-2.1988\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Informative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml2/reference.ISO.8571-2.1988.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 
 		"Hey, what about [@!ISO.8571-2.1988]",
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\nHey, what about <xref target=\"ISO.8571-2.1988\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Normative References</name>\n<xi:include href=\"http://xml2rfc.ietf.org/public/rfc/bibxml2/reference.ISO.8571-2.1988.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<t>\nHey, what about <xref target=\"ISO.8571-2.1988\"/>\n</t>\n\n</middle>\n<back>\n<references>\n<name>Normative References</name>\n<xi:include href=\"https://xml2rfc.tools.ietf.org/public/rfc/bibxml2/reference.ISO.8571-2.1988.xml\"/>\n</references>\n\n</back>\n</rfc>\n",
 	}
 	doTestsInlineParamXML(t, tests, 0, XML_STANDALONE)
 }

--- a/xml2rfc.go
+++ b/xml2rfc.go
@@ -13,18 +13,19 @@ import (
 
 var (
 	// These have been known to change, these are the current ones (2015-08-27).
+        CitationsBase = "https://xml2rfc.tools.ietf.org/public/rfc/"
 
 	// CitationsRFC is the URL where the citations for RFCs are.
-	CitationsRFC = "http://xml2rfc.ietf.org/public/rfc/bibxml/"
+	CitationsRFC = CitationsBase + "bibxml/"
 
 	// CitationsANSI is the URL where the citations for ANSI documents are.
-	CitationsANSI = "http://xml2rfc.ietf.org/public/rfc/bibxml2/"
+	CitationsANSI = CitationsBase + "bibxml2/"
 
 	// CitationsID is the URL where the citations for I-Ds are.
-	CitationsID = "http://xml2rfc.ietf.org/public/rfc/bibxml3/"
+	CitationsID = CitationsBase + "bibxml3/"
 
 	// CitationsW3C is the URL where the citations for W3C documents are.
-	CitationsW3C = "http://xml2rfc.ietf.org/public/rfc/bibxml4/"
+	CitationsW3C = CitationsBase + "bibxml4/"
 )
 
 const (


### PR DESCRIPTION
There's probably a case for allowing someone to set the base, but this works.