### PR TITLE
AddingPowerSupport_CI/Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch:
+    - amd64
+    - ppc64le
+    
 language: go
 
 go:


### PR DESCRIPTION
Adding power support.

Adding power support ppc64le with Continues Integration/testing so that code remains architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

Please let me know if there are any further questions on this.
Thank You !!